### PR TITLE
Events type is bytes, not bytearray

### DIFF
--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -32,7 +32,7 @@ void Decoder::decode_bytes(
   if (decoder) {
     decoder->setTimeBase(timeBase);
     decoder->setTimeMultiplier(1);  // report in usecs instead of nanoseconds
-    const size_t bufSize = PyByteArray_GET_SIZE(events.ptr());
+    const size_t bufSize = PyBytes_Size(events.ptr());
     // for some reason this returns a bad pointer
     // const uint8_t *buf = reinterpret_cast<uint8_t *>(PyByteArray_AsString(events.ptr()));
     // TODO(Bernd): avoid the memory copy here

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -32,11 +32,6 @@ void Decoder::decode_bytes(
   if (decoder) {
     decoder->setTimeBase(timeBase);
     decoder->setTimeMultiplier(1);  // report in usecs instead of nanoseconds
-    const size_t bufSize = PyBytes_Size(events.ptr());
-    // for some reason this returns a bad pointer
-    // const uint8_t *buf = reinterpret_cast<uint8_t *>(PyByteArray_AsString(events.ptr()));
-    // TODO(Bernd): avoid the memory copy here
-    const std::string foo(events);  // creates unnecessary copy!
     delete cdEvents_;               // in case events have not been picked up
     cdEvents_ = new std::vector<EventCD>();
     delete extTrigEvents_;  // in case events have not been picked up
@@ -44,8 +39,8 @@ void Decoder::decode_bytes(
     // TODO(Bernd): use hack here to avoid initializing the memory
     cdEvents_->reserve(maxSizeCD_);
     extTrigEvents_->reserve(maxSizeExtTrig_);
-    const uint8_t * buf = reinterpret_cast<const uint8_t *>(&foo[0]);
-    decoder->decode(buf, bufSize, this);
+    const uint8_t * buf = reinterpret_cast<const uint8_t *>(PyBytes_AsString(events.ptr()));
+    decoder->decode(buf, PyBytes_Size(events.ptr()), this);
   }
 }
 


### PR DESCRIPTION
The `decode_bytes` prototype specifies events as `bytes`.
```
  void decode_bytes(
    const std::string & encoding, uint16_t width, uint16_t height, uint64_t timeBase,
    pybind11::bytes events);
```
but `decoder.c` tries to decode it as a bytearray. This can trigger the following issue with a simple EventArray message, that yields an immutable object for `events`.
```
>>> a = event_array_msgs.msg.EventArray()
>>> a
header:
  seq: 0
  stamp:
    secs: 0
    nsecs:         0
  frame_id: ''
height: 0
width: 0
seq: 0
time_base: 0
encoding: ''
is_bigendian: False
events: []
>>> type(a.events)
<class 'bytes'>
```
```
python3.8-dbg: /home/fclad/catkin_ws/src/event_array_py/src/decoder.cpp:35: 
void Decoder::decode_bytes(const string&, uint16_t, uint16_t, uint64_t, pybind11::bytes): Assertion `PyByteArray_Check(events.ptr())' failed.
```
This patch fixes the problem.