### PR TITLE
breaking change: return None if find_first_sensor_time fails

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,11 +12,6 @@ on:
     branches: [master]
 
 jobs:
-  build_ros1:
-    uses: ros-misc-utilities/ros_build_scripts/.github/workflows/ros1_ci.yml@master
-    with:
-      repo: ${{ github.event.repository.name }}
-      vcs_url: https://raw.githubusercontent.com/${{ github.repository }}/master/${{ github.event.repository.name }}.repos
   build_ros2:
     uses: ros-misc-utilities/ros_build_scripts/.github/workflows/ros2_recent_ci.yml@master
     with:

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -95,7 +95,7 @@ void declare_decoder(pybind11::module & m, std::string typestr)
         :rtype: tuple[boolean, uint64_t]
         )pbdoc")
     .def("find_first_sensor_time", &MyDecoder::find_first_sensor_time, R"pbdoc(
-        find_first_sensor_time(msg) -> tuple[Boolean, uint64_t]
+        find_first_sensor_time(msg) -> uint64|None
 
         Peeks into encoded message to find first event sensor time stamp. The
         boolean return flag indicates whether any time stamp was detected.
@@ -105,8 +105,8 @@ void declare_decoder(pybind11::module & m, std::string typestr)
 
         :param msg: event packet message to decode
         :type msg:  event_camera_msgs/msgs/EventPacket
-        :return: tuple with flag (true if event sensor time was found) and the sensor time
-        :rtype: tuple[boolean, uint64_t]
+        :return: sensor time
+        :rtype:  uint64_t or None if not found
         )pbdoc")
     .def("get_start_time", &MyDecoder::get_start_time, R"pbdoc(
         get_start_time() -> uint64

--- a/tests/test_1.py
+++ b/tests/test_1.py
@@ -188,8 +188,8 @@ def test_find_first_sensor_time(verbose=True):
         print('Testing find_first_time_stamp')
     decoder = Decoder()
     for _, msg, _ in bag.read_messages(topics=['/event_camera/events']):
-        found_ts, ts = decoder.find_first_sensor_time(msg)
-        assert found_ts
+        ts = decoder.find_first_sensor_time(msg)
+        assert ts is not None
         if verbose:
             print('first sensor time stamp: ', ts)
         assert ts == 7139840


### PR DESCRIPTION
This PR changes the interface for find_first_sensor_time and fixes a bug that bites
when time_base is used (e.g. libcaer).
